### PR TITLE
Add /tpall to plugin.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.comfy</groupId>
     <artifactId>LegionTest1</artifactId>
-    <version>v1.13.1</version>
+    <version>1.13.2</version>
     <packaging>jar</packaging>
 
     <name>LegionTest1</name>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -60,6 +60,8 @@ commands:
   tp:
     aliases:
       - teleport
+  tpall:
+    permission: legiontest.tpall
   badday:
     description: :)
   staffhome:


### PR DESCRIPTION
Fixes the plugin not loading due to `/tpall` missing in the `plugin.yml`.